### PR TITLE
Prompt to remove the remote branch

### DIFF
--- a/ask/ask.go
+++ b/ask/ask.go
@@ -1,0 +1,32 @@
+package ask
+
+import (
+	"bufio"
+	"github.com/remotemobprogramming/mob/v5/say"
+	"io"
+	"os"
+	"strings"
+)
+
+func YesNo(q string) bool {
+	say.Say(q)
+	reader := ReadFromConsole(io.Reader(os.Stdin))
+	for {
+		text, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			say.Error("Error reading from console")
+			return false
+		}
+
+		if strings.ToLower(text) == "y\n" || text == "\n" {
+			return true
+		} else {
+			say.Say("Aborted")
+			return false
+		}
+	}
+}
+
+var ReadFromConsole = func(reader io.Reader) *bufio.Reader {
+	return bufio.NewReader(reader)
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -154,8 +154,6 @@ func ParseArgs(args []string, configuration Configuration) (command string, para
 			newConfiguration.StartCreate = true
 		case "--join", "-j":
 			newConfiguration.StartJoin = true
-		case "--delete-remote-wip-branch":
-			newConfiguration.ResetDeleteRemoteWipBranch = true
 		case "--room":
 			if i+1 != len(args) {
 				newConfiguration.TimerRoom = args[i+1]

--- a/mob.go
+++ b/mob.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/remotemobprogramming/mob/v5/ask"
 	config "github.com/remotemobprogramming/mob/v5/configuration"
 	"github.com/remotemobprogramming/mob/v5/goal"
 	"github.com/remotemobprogramming/mob/v5/help"
@@ -519,8 +520,8 @@ func moo(configuration config.Configuration) {
 func reset(configuration config.Configuration) {
 	if configuration.ResetDeleteRemoteWipBranch {
 		deleteRemoteWipBranch(configuration)
-	} else {
-		say.Fix("Executing this command deletes the mob branch for everyone. If you're sure you want that, use", configuration.Mob("reset --delete-remote-wip-branch"))
+	} else if ask.YesNo("Executing this command deletes the mob branch for everyone. Are you sure you want to continue? (Y/n)") {
+		deleteRemoteWipBranch(configuration)
 	}
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"github.com/remotemobprogramming/mob/v5/ask"
 	config "github.com/remotemobprogramming/mob/v5/configuration"
 	"github.com/remotemobprogramming/mob/v5/open"
 	"github.com/remotemobprogramming/mob/v5/say"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -416,7 +419,7 @@ func TestReset(t *testing.T) {
 
 	reset(configuration)
 
-	assertOutputContains(t, output, "mob reset --delete-remote-wip-branch")
+	assertOutputContains(t, output, "Executing this command deletes the mob branch for everyone. Are you sure you want to continue? (Y/n)")
 }
 
 func TestResetDeleteRemoteWipBranch(t *testing.T) {
@@ -435,10 +438,11 @@ func TestResetCommit(t *testing.T) {
 	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 	assertMobSessionBranches(t, configuration, "mob-session")
+	simulateUserInput("y")
 
 	reset(configuration)
 
-	assertOutputContains(t, output, "mob reset --delete-remote-wip-branch")
+	assertOutputContains(t, output, "Executing this command deletes the mob branch for everyone. Are you sure you want to continue? (Y/n)")
 	assertMobSessionBranches(t, configuration, "mob-session")
 }
 
@@ -463,10 +467,12 @@ func TestResetCommitBranch(t *testing.T) {
 	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 	assertMobSessionBranches(t, configuration, "mob/master-green")
+	simulateUserInput("n")
 
 	reset(configuration)
 
-	assertOutputContains(t, output, "mob reset --delete-remote-wip-branch")
+	assertOutputContains(t, output, "Executing this command deletes the mob branch for everyone. Are you sure you want to continue? (Y/n)")
+	assertOutputContains(t, output, "Aborted")
 	assertMobSessionBranches(t, configuration, "mob/master-green")
 }
 
@@ -2013,6 +2019,12 @@ func setup(t *testing.T) (output *string, configuration config.Configuration) {
 	assertNoMobSessionBranches(t, configuration, "mob-session")
 	output = captureOutput(t)
 	return output, configuration
+}
+
+func simulateUserInput(a string) {
+	ask.ReadFromConsole = func(reader io.Reader) *bufio.Reader {
+		return bufio.NewReader(strings.NewReader(a))
+	}
 }
 
 func captureOutput(t *testing.T) *string {


### PR DESCRIPTION
Replace `--delete-remote-wip-branch` with a prompt for the user on whether they would like to continue

- Kept User Config in place to retain default behaviour
- Updated the tests